### PR TITLE
Update Detekt monorepo from 2.0.0-alpha.2 to 2.0.0-alpha.3

### DIFF
--- a/detekt-testing/src/main/kotlin/net/twisterrob/detekt/testing/PsiTestingExtension.kt
+++ b/detekt-testing/src/main/kotlin/net/twisterrob/detekt/testing/PsiTestingExtension.kt
@@ -1,8 +1,9 @@
 package net.twisterrob.detekt.testing
 
-import org.junit.jupiter.api.extension.AfterEachCallback
-import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.InvocationInterceptor
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext
+import java.lang.reflect.Method
 
 /**
  * JUnit Jupiter extension that enables [com.intellij.psi.impl.DebugUtil.CHECK] for each test.
@@ -11,14 +12,17 @@ import org.junit.jupiter.api.extension.ExtensionContext
  *
  * @see fix
  */
-@Suppress("detekt.UnnecessaryFullyQualifiedName")
-public class PsiTestingExtension : BeforeEachCallback, AfterEachCallback {
+public class PsiTestingExtension : InvocationInterceptor {
 
-	override fun beforeEach(context: ExtensionContext) {
-		com.intellij.psi.impl.DebugUtil.CHECK = true
-	}
-
-	override fun afterEach(context: ExtensionContext) {
-		com.intellij.psi.impl.DebugUtil.CHECK = false
+	override fun interceptTestMethod(
+		@Suppress("detekt.ForbiddenVoid") // JUnit API.
+		invocation: InvocationInterceptor.Invocation<Void?>,
+		invocationContext: ReflectiveInvocationContext<Method>,
+		extensionContext: ExtensionContext,
+	) {
+		@Suppress("detekt.UnnecessaryFullyQualifiedName")
+		com.intellij.psi.impl.DebugUtil.runWithCheckInternalInvariantsEnabled {
+			invocation.proceed()
+		}
 	}
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ kotlin-build = "2.4.10"
 kotlin-target = { strictly = "2.4.10" }
 kotlin-language = "2.1"
 
-detekt = "2.0.0-alpha.2"
+detekt = "2.0.0-alpha.3"
 
 junit-jupiter = "6.1.2"
 hamcrest = "1.3"


### PR DESCRIPTION
Updates Detekt from 2.0.0-alpha.2 to 2.0.0-alpha.3.

Adapts the PSI test extension because DebugUtil.CHECK is private with Detekt's Kotlin 2.3.21 compiler; tests now use the scoped public invariant-check API.

Validated with:

`gradlew --stacktrace --continue -Pnet.twisterrob.detekt.build.compile-test-snippets=true build detektMain detektTest`