### PR TITLE
Update Detekt monorepo from 2.0.0-alpha.4 to 2.0.0-alpha.5

### DIFF
--- a/detekt-browser/build.gradle
+++ b/detekt-browser/build.gradle
@@ -11,9 +11,7 @@ dependencies {
 	api(libs.detekt.rules.coroutines)
 	api(libs.detekt.rules.emptyBlocks)
 	api(libs.detekt.rules.exceptions)
-	api(libs.detekt.rules.ktlintWrapper) {
-		exclude group: "dev.detekt", module: "ktlint-repackage"
-	}
+	api(libs.detekt.rules.ktlintWrapper)
 	api(libs.detekt.rules.libraries)
 	api(libs.detekt.rules.naming)
 	api(libs.detekt.rules.performance)

--- a/detekt-testing/build.gradle
+++ b/detekt-testing/build.gradle
@@ -3,10 +3,11 @@ plugins {
 }
 
 dependencies {
-	// TODEL https://github.com/detekt/detekt/pull/9439
 	api(libs.detekt.test) {
+		// TODEL https://github.com/detekt/detekt/pull/9439
 		exclude group: "dev.detekt", module: "detekt-api"
 	}
+	// TODEL https://github.com/detekt/detekt/pull/9439
 	api(libs.detekt.api)
 	implementation(libs.kotlin.reflect)
 	implementation(libs.detekt.core)

--- a/detekt-testing/build.gradle
+++ b/detekt-testing/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 dependencies {
+	// TODEL https://github.com/detekt/detekt/pull/9439
 	api(libs.detekt.test) {
 		exclude group: "dev.detekt", module: "detekt-api"
 	}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ kotlin-build = "2.4.10"
 kotlin-target = { strictly = "2.4.10" }
 kotlin-language = "2.1"
 
-detekt = "2.0.0-alpha.4"
+detekt = "2.0.0-alpha.5"
 
 junit-jupiter = "6.1.2"
 hamcrest = "1.3"

--- a/gradle/plugins/build.gradle.kts
+++ b/gradle/plugins/build.gradle.kts
@@ -4,9 +4,7 @@ plugins {
 
 dependencies {
 	api(libs.plugin.kotlin)
-	api(libs.plugin.detekt) {
-		exclude(group = "org.gradle.experimental", module = "gradle-public-api")
-	}
+	api(libs.plugin.detekt)
 	api(libs.plugin.intellij)
 
 	// TODEL https://github.com/gradle/gradle/issues/15383


### PR DESCRIPTION
Updates Detekt from 2.0.0-alpha.4 to 2.0.0-alpha.5.

Removes the alpha.4 workarounds for incorrectly published Gradle public-API and ktlint-repackage dependencies. Retains the API test-fixtures workaround because alpha.5 still requests the unavailable capability; it is fixed on Detekt main by [#9439](https://github.com/detekt/detekt/pull/9439).

Validated with:

`gradlew --stacktrace --continue -Pnet.twisterrob.detekt.build.compile-test-snippets=true build detektMain detektTest`